### PR TITLE
[Bugfix] 댓글 및 리뷰 주체를 github-actions 로 수정

### DIFF
--- a/.github/workflows/code_review.yaml
+++ b/.github/workflows/code_review.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: ChatGPT
         uses: anc95/ChatGPT-CodeReview@main
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           MODEL: gpt-3.5-turbo
           PROMPT: |

--- a/.github/workflows/run_ci.yaml
+++ b/.github/workflows/run_ci.yaml
@@ -23,7 +23,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             await github.pulls.createReview({
               owner: context.repo.owner,
@@ -49,7 +49,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             await github.pulls.createReview({
               owner: context.repo.owner,


### PR DESCRIPTION
## PR 설명

yaml 내 GITHUB_TOKEN 이 아닌 TOKEN 으로 작성되어서
깃허브 액션이 아닌 제 자신이 댓글을 남기는 형태가 되는 문제를 해결했습니다.

## 관련 이슈

- Resolved: #13