### PR TITLE
[Fix] 미들웨어의 callback URL 이스케이프 문제해결

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,7 +6,9 @@ export async function middleware(request: NextRequest) {
   const callbackUrl = request.nextUrl.pathname + request.nextUrl.search
 
   if (!token) {
-    return NextResponse.redirect(new URL(`/login?cb=${callbackUrl}`, request.url))
+    const url = new URL('/login', request.url)
+    url.searchParams.set('cb', callbackUrl)
+    return NextResponse.redirect(url)
   }
 
   try {
@@ -14,8 +16,8 @@ export async function middleware(request: NextRequest) {
     await jwtVerify(token, secret)
 
     return NextResponse.next()
-  } catch (error) {
-    return NextResponse.redirect(new URL(`/login?cb=${error}`, request.url))
+  } catch {
+    return NextResponse.redirect(new URL(`/login`, request.url))
   }
 }
 


### PR DESCRIPTION
## PR 설명

Next.js 미들웨어에서 인증 토큰이 없는 경우, 로그인 페이지로 리다이렉트 될 때, 콜백 URL 을 쿼리 파라미터로 전달합니다.
로컬에서는 /write 와 같이 올바른 URL 이 전달되지만, 배포 환경에서는 %2Fwrite 같이 의도하지 않은 형태로 표시되는 문제를 해결했습니다.

## 관련 이슈

- Resolved: #29
